### PR TITLE
LPS-45658 Dialog Iframe has too much body padding

### DIFF
--- a/portal-web/docroot/html/themes/_styled/css/aui.css
+++ b/portal-web/docroot/html/themes/_styled/css/aui.css
@@ -13,6 +13,14 @@ $FontAwesomePath: "aui/alloy-font-awesome/font" !default;
 	@import "aui/bootstrap";
 	@import "aui_custom";
 	@import "aui/responsive";
+
+	@media (max-width: 767px) {
+		body.dialog-iframe-popup {
+			padding-left: 0;
+			padding-right: 0;
+		}
+	}
+
 	@import "liferay_custom";
 
 	@import "aui/alloy-font-awesome/scss/core";
@@ -27,4 +35,6 @@ $FontAwesomePath: "aui/alloy-font-awesome/font" !default;
 	font-size: $baseFontSize;
 	line-height: $baseLineHeight;
 	margin: 0;
+
+
 }


### PR DESCRIPTION
For widths under 767px, body padding is added to the dialog iframe element
unecessarily. This rule is from a scss file from alloy bootstrap, and is
included in aui.css with the line '@import "aui/responsive"'. (See:
https://github.com/liferay/alloy-bootstrap/blob/master/lib/_responsive-767px-max.scss)
A rule is added to this file to override that padding for the dialog
iframe windows in the _styled theme and then its children