### PR TITLE
LPS-89414 Add condition for AlloyEditor and CKEditor for images

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-image-js-web/src/main/resources/META-INF/resources/ckeditor/plugins/adaptivemedia/plugin.js
+++ b/modules/apps/adaptive-media/adaptive-media-image-js-web/src/main/resources/META-INF/resources/ckeditor/plugins/adaptivemedia/plugin.js
@@ -132,7 +132,7 @@
 
 				if (instance._isEmptySelection(editor)) {
 					if (IE9) {
-						editor.insertHtml('<br />');
+						editor.contextMenu ? editor.insertHtml('<br />') : editor.insertHtml(el.getOuterHtml() + '<br />');
 					}
 					else {
 						editor.execCommand('enter');

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
@@ -408,7 +408,7 @@
 
 									if (instance._isEmptySelection(editor)) {
 										if (IE9) {
-											editor.insertHtml('<br />');
+											editor.contextMenu ? editor.insertHtml('<br />') : editor.insertHtml('<img src="' + imageSrc + '"><br />');
 										}
 										else {
 											editor.execCommand('enter');


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-89414
Resent from https://github.com/gregory-bretall/liferay-portal/pull/149

Original fix caused a regression specific to AlloyEditor. Not sure if there's a better way to differentiate between alloy/ck than this, let me know if you have any ideas.