### PR TITLE
LPS-95489 Apply getDocumentPosition on editorElement.getLast() instea…

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/extension/dialog_definition.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/extension/dialog_definition.js
@@ -14,7 +14,7 @@ CKEDITOR.on(
 				if (window.top != window.self) {
 					var editorElement = this.getParentEditor().container;
 
-					var documentPosition = editorElement.getDocumentPosition();
+					var documentPosition = editorElement.getLast().getDocumentPosition();
 
 					var dialogSize = this.getSize();
 


### PR DESCRIPTION
…d of editorElement

Looking for your thoughts on this, as far as I can tell it's not reproducible in master but should still theoretically apply.

Resent from https://github.com/gregory-bretall/liferay-portal/pull/196

https://issues.liferay.com/browse/LPS-95489